### PR TITLE
Feat/footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/wt-ui-react",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "React framework",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/Footer/About.jsx
+++ b/src/components/Footer/About.jsx
@@ -1,0 +1,18 @@
+/* @flow */
+import React from 'react';
+
+const About = () => (
+  <div className="col-6 col-md-3">
+    <dl className="mb-1">
+      <dt className="mb-1">About</dt>
+      <dd>
+        <nav className="nav flex-column small">
+          <a href="https://windingtree.com" className="nav-link px-0 text-white text--alpha-inverse">Homepage</a>
+          <a href="https://blog.windingtree.com/" className="nav-link px-0 text-white text--alpha-inverse">Blog</a>
+        </nav>
+      </dd>
+    </dl>
+  </div>
+);
+
+export default About;

--- a/src/components/Footer/Comunity.jsx
+++ b/src/components/Footer/Comunity.jsx
@@ -1,0 +1,17 @@
+/* @flow */
+import React from 'react';
+
+const Comunity = () => (
+  <div className="col-6 col-md-3">
+    <dl className="mb-1">
+      <dt className="mb-1">Community</dt>
+      <dd>
+        <nav className="nav flex-column small">
+          <a href="/startups-and-developers.html" className="nav-link px-0 text-white text-alpha-inverse">For developers &amp;&nbsp;startups</a>
+        </nav>
+      </dd>
+    </dl>
+  </div>
+);
+
+export default Comunity;

--- a/src/components/Footer/Contacts.jsx
+++ b/src/components/Footer/Contacts.jsx
@@ -1,0 +1,20 @@
+/* @flow */
+import React from 'react';
+
+const Contacts = () => (
+  <div className="col-6 col-md-3">
+    <dl className="mb-1">
+      <dt className="mb-1">Contacts</dt>
+      <dd>
+        <nav className="nav flex-column small">
+          <span className="nav-link px-0">
+            Gubelstrasse 11, 6300 Zug, Switzerland
+          </span>
+          <a href="mailto:info@windingtree.com" className="nav-link px-0 text-white text-alpha-inverse text-truncate">info@windingtree.com</a>
+        </nav>
+      </dd>
+    </dl>
+  </div>
+);
+
+export default Contacts;

--- a/src/components/Footer/Copyright.jsx
+++ b/src/components/Footer/Copyright.jsx
@@ -1,0 +1,15 @@
+/* @flow */
+import React from 'react';
+
+const Copyright = () => (
+  <div className="d-flex flex-column flex-md-row align-items-center align-items-md-baseline">
+    <small>
+©&nbsp;2017–
+      <script>document.write(new Date().getFullYear());</script>
+2018, Winding Tree
+    </small>
+    <a href="https://windingtree.com/" target="_blank" rel="noopener noreferrer" className="ml-md-2 small text-white text-alpha-inverse border-bottom">powered by Winding Tree</a>
+  </div>
+);
+
+export default Copyright;

--- a/src/components/Footer/Developers.jsx
+++ b/src/components/Footer/Developers.jsx
@@ -1,0 +1,19 @@
+/* @flow */
+import React from 'react';
+
+const Developers = () => (
+  <div className="col-6 col-md-3">
+    <dl className="mb-1">
+      <dt className="mb-1">Developers</dt>
+      <dd>
+        <nav className="nav flex-column small">
+          <a href="https://github.com/windingtree/wt-hotel-explorer" className="nav-link px-0 text-white text--alpha-inverse">Source code</a>
+          <a href="https://github.com/windingtree" className="nav-link px-0 text-white text--alpha-inverse">GitHub</a>
+          <a href="https://groups.google.com/forum/#!forum/windingtree" className="nav-link px-0 text-white text--alpha-inverse">Google Group</a>
+        </nav>
+      </dd>
+    </dl>
+  </div>
+);
+
+export default Developers;

--- a/src/components/Footer/IconList.jsx
+++ b/src/components/Footer/IconList.jsx
@@ -1,0 +1,46 @@
+/* @flow */
+import React from 'react';
+
+const IconList = () => (
+  <div className="mb-1 mb-md-0 ml-md-auto">
+    <ul className="social list-inline text-center text-md-right">
+      <li className="list-inline-item">
+        <a href="https://github.com/windingtree" title="GitHub" className="text-white text--alpha">
+          <i className="mdi mdi-24px mdi-github-circle" />
+        </a>
+      </li>
+      <li className="list-inline-item">
+        <a href="https://twitter.com/windingtree" title="Twitter" className="text-white text--alpha">
+          <i className="mdi mdi-24px mdi-twitter" />
+        </a>
+      </li>
+      <li className="list-inline-item">
+        <a href="http://blog.windingtree.com/" title="Medium" className="text-white text--alpha">
+          <i className="mdi mdi-24px mdi-medium" />
+        </a>
+      </li>
+      <li className="list-inline-item">
+        <a href="https://www.youtube.com/channel/UCFuemEOhCfenYMoNdjD0Aew" title="YouTube" className="text-white text--alpha">
+          <i className="mdi mdi-24px mdi-youtube" />
+        </a>
+      </li>
+      <li className="list-inline-item">
+        <a href="https://t.me/windingtree" title="Telegram" className="text-white text--alpha">
+          <i className="mdi mdi-24px mdi-telegram" />
+        </a>
+      </li>
+      <li className="list-inline-item">
+        <a href="https://reddit.com/r/windingtree" title="Reddit" className="text-white text--alpha">
+          <i className="mdi mdi-24px mdi-reddit" />
+        </a>
+      </li>
+      <li className="list-inline-item">
+        <a href="https://bitcointalk.org/index.php?topic=1946065" title="BitcoinTalk" className="text-white text--alpha">
+          <i className="mdi mdi-24px mdi-bitcoin" />
+        </a>
+      </li>
+    </ul>
+  </div>
+);
+
+export default IconList;

--- a/src/components/Footer/Lif-token.jsx
+++ b/src/components/Footer/Lif-token.jsx
@@ -1,0 +1,19 @@
+/* @flow */
+import React from 'react';
+
+const LifToken = () => (
+  <div className="col-6 col-md-3">
+    <dl className="mb-1">
+      <dt className="mb-1">Lif Token</dt>
+      <dd>
+        <nav className="nav flex-column small">
+          <a href="/lif-token.html" className="nav-link px-0 text-white text-alpha-inverse">About token</a>
+          <a href="/lif-token.html" className="nav-link px-0 text-white text-alpha-inverse">Buy Lifs</a>
+          <a href="/lif-token.html" className="nav-link px-0 text-white text-alpha-inverse">Smart contract</a>
+        </nav>
+      </dd>
+    </dl>
+  </div>
+);
+
+export default LifToken;

--- a/src/components/Footer/Logo.jsx
+++ b/src/components/Footer/Logo.jsx
@@ -1,0 +1,11 @@
+/* @flow */
+import React from 'react';
+
+const Logo = () => (
+  <div className="col-md-4">
+    <img src="https://windingtree.com/assets/img/logo/sm-white.svg" alt="Winding Tree" className="d-md-none mb-2" />
+    <img src="https://windingtree.com/assets/img/logo/md-white.svg" height="60" alt="Winding Tree" className="d-none d-md-inline" />
+  </div>
+);
+
+export default Logo;

--- a/src/components/Footer/Solutions.jsx
+++ b/src/components/Footer/Solutions.jsx
@@ -1,0 +1,20 @@
+/* @flow */
+import React from 'react';
+
+const Solutions = () => (
+  <div className="col-6 col-md-3">
+    <dl className="mb-1">
+      <dt className="mb-1">Solutions</dt>
+      <dd>
+        <nav className="nav flex-column small">
+          <a href="/suppliers.html" className="nav-link px-0 text-white text-alpha-inverse">For travel suppliers</a>
+          <a href="/sellers.html" className="nav-link px-0 text-white text-alpha-inverse">For sellers of travel</a>
+          <a href="/software-vendors.html" className="nav-link px-0 text-white text-alpha-inverse">For software vendors</a>
+          <a href="https://github.com/windingtree/" className="nav-link px-0 text-white text-alpha-inverse">API</a>
+        </nav>
+      </dd>
+    </dl>
+  </div>
+);
+
+export default Solutions;

--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -1,0 +1,39 @@
+/* @flow */
+import React from 'react';
+import IconList from './IconList';
+import Copyright from './Copyright';
+import Logo from './Logo';
+import './styles.scss';
+
+type PropsType = {
+  children: React$Node
+};
+
+const WTFooter = (props: PropsType) => {
+  const { children } = props;
+  return (
+    <footer className="footer bg-accent text-white">
+      <div className="container">
+        <div className="footer__row pt-2 pb-1">
+          <div className="row">
+            <Logo />
+            <div className="col-md-8">
+              <div className="row">
+                {children}
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr className="text-alpha" />
+        <div className="py-1">
+          <div className="d-flex flex-column-reverse flex-md-row align-items-center">
+            <Copyright />
+            <IconList />
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default WTFooter;

--- a/src/components/Footer/styles.scss
+++ b/src/components/Footer/styles.scss
@@ -1,0 +1,5 @@
+@import '~@windingtree/wt-ui/dist/styles'; 
+
+footer hr {
+  margin: 0;
+}

--- a/stories/footer.stories.jsx
+++ b/stories/footer.stories.jsx
@@ -1,0 +1,33 @@
+/* @flow */
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import '@windingtree/wt-ui/dist/styles.css';
+
+import Footer from 'components/Footer';
+import About from 'components/Footer/About';
+import Comunity from 'components/Footer/Comunity';
+import Contacts from 'components/Footer/Contacts';
+import Developers from 'components/Footer/Developers';
+import LifToken from 'components/Footer/Lif-token';
+import Solutions from 'components/Footer/Solutions';
+
+
+storiesOf('Footer', module)
+  .add('Baisc Footer', () => (
+  <Footer>
+    <About />
+    <Developers />
+  </Footer>
+  ))
+  .add('Full Footer', () => (
+    <Footer>
+      <About />
+      <LifToken />
+      <Comunity />
+      <Developers />
+      <Solutions />
+      <Contacts />
+    </Footer>
+    ));


### PR DESCRIPTION
This closes #12 

After trying to use React-bootstrap components, the library is adding default classes to each component. This components are not edited in our custom framework. So for now is impossible to use property full react components. For example, using `List` and `List.Item` as `dl`, `dt`, etc. It add default classes, that add margins, padding, white background, etc. This classes aren't modified in wt-ui so we need to override all the default behavior, in each component. So is a really bad idea.

- [ ] We need to define how to handle relative paths. Maybe use full paths is a better idea.
