### PR TITLE
fix(npm): Change entry point to dist/main.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@windingtree/wt-ui-react",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "React framework",
-  "main": "dist/index.js",
+  "main": "dist/main.js",
   "scripts": {
     "build": "webpack --config ./webpack/webpack.config.js --mode production",
     "coverage": "cat coverage/lcov.info | coveralls",


### PR DESCRIPTION
Fixes a bug that entry point was pointing to `dist/index.js` preventing to import components.